### PR TITLE
Fix handling of directory order in RELATIVE-PATHNAME

### DIFF
--- a/test.lisp
+++ b/test.lisp
@@ -284,6 +284,7 @@
   (is pathname= #p"a/" (relative-pathname #p"/" #p"/a/"))
   (is pathname= #p"a" (relative-pathname #p"/" #p"/a"))
   (is pathname= #p"b/c" (relative-pathname #p"a/" #p"a/b/c"))
+  (is pathname= #p"b/c/" (relative-pathname #p"a/" #p"a/b/c/"))
   (is pathname= (make-pathname :directory '(:relative :up "d")) (relative-pathname #p"/a/b/" #p"/a/d/")))
 
 (define-test file-in

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -247,7 +247,7 @@
             do (pop from-dir) (pop to-dir))
       (loop repeat (length from-dir)
             do (push :up final-dir))
-      (loop for to in (reverse to-dir)
+      (loop for to in to-dir
             do (push to final-dir))
       (make-pathname :directory (unless (equal '(:relative) final-dir)
                                   (nreverse final-dir))


### PR DESCRIPTION
This fixes a small bug in `RELATIVE-PATHNAME`, namely that the directory part of the `TO` pathname was getting reversed. Previously, 
```
PATHNAME-UTILS> (relative-pathname "/a/" "/a/b/c/")
#P"c/b/"
```
and now
```
PATHNAME-UTILS> (relative-pathname "/a/" "/a/b/c/")
#P"b/c/"
```

The previous tests missed this one, since the only considered paths were ones where the relative pathname had a single directory.